### PR TITLE
Fix #14 extension not working

### DIFF
--- a/background.js
+++ b/background.js
@@ -53,17 +53,10 @@ function getDuration(vId, apiKey){
 	});
 }
 
-function makeSearchTerms(tSec){
-	return new Promise((resolve, reject) => {
-		let urlsTerms = "";
-		resolve(urlsTerms);
-	});
-}
-
-function makeUrl(videoId, apiKey, pageToken, sTerms){
+function makeUrl(videoId, apiKey, pageToken){
 	const fields = "&fields=items%28snippet%2FtopLevelComment%2Fsnippet%2FtextOriginal%2C%20snippet%2FtopLevelComment%2Fsnippet%2FauthorDisplayName%2Csnippet%2FtopLevelComment%2Fid%29%2CnextPageToken";
 	let url = "https://www.googleapis.com/youtube/v3/commentThreads?part=snippet&videoId=";
-	url += videoId.toString() + "&maxResults=100" + fields + "&key=" + apiKey.toString() + sTerms;
+	url += videoId.toString() + "&maxResults=100" + fields + "&key=" + apiKey.toString();
 	if(pageToken != -1){
 		url += "&pageToken=" + pageToken.toString();
 	}
@@ -90,14 +83,14 @@ function filterComments(comments){
 	return res;
 }
 
-function fetchComments(vId, apiKey, pageToken, sTerms){
+function fetchComments(vId, apiKey, pageToken){
 	return new Promise((resolve, reject) => {
-		fetch(makeUrl(vId, apiKey, pageToken, sTerms)).then(r => r.text()).then(r => {
+		fetch(makeUrl(vId, apiKey, pageToken)).then(r => r.text()).then(r => {
 			let final = JSON.parse(r);
 			if(!("nextPageToken" in final)){
 				resolve(final["items"]);
 			} else {
-				fetchComments(vId, apiKey, final["nextPageToken"], sTerms).then(r => {
+				fetchComments(vId, apiKey, final["nextPageToken"]).then(r => {
 					resolve(final["items"].concat(r));
 				});
 			}
@@ -111,10 +104,8 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	const apiKey = config.API_KEY;
     if(request.getComments === "True"){
 		getDuration(vId, apiKey).then(s => {
-			makeSearchTerms(s).then(sTerms => {
-				fetchComments(vId, apiKey, -1, sTerms).then(result => {
-					sendResponse({"comments": filterComments(result), "videoId": vId, "videoDuration": s-1});
-				});
+			fetchComments(vId, apiKey, -1).then(result => {
+				sendResponse({"comments": filterComments(result), "videoId": vId, "videoDuration": s-1});
 			});
 		});
     }
@@ -138,10 +129,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 					response = response || {}
 					if(response.status){
 						getDuration(vId, apiKey).then(s => {
-							makeSearchTerms(s).then(sTerms => {
-								fetchComments(vId, apiKey, -1, sTerms).then(result => {
-									chrome.tabs.sendMessage(tabId, {tabUpdated: true, comments: filterComments(result), videoId: vId, videoDuration: s-1}, function(response) {});
-								});
+							fetchComments(vId, apiKey, -1).then(result => {
+								chrome.tabs.sendMessage(tabId, {tabUpdated: true, comments: filterComments(result), videoId: vId, videoDuration: s-1}, function(response) {});
 							});
 						});
 					} else {

--- a/background.js
+++ b/background.js
@@ -1,5 +1,4 @@
 importScripts('config.js');
-console.log("asdjf")
 
 function getId(fullUrl){
 	let videoId = fullUrl.split('v=')[1];
@@ -56,16 +55,7 @@ function getDuration(vId, apiKey){
 
 function makeSearchTerms(tSec){
 	return new Promise((resolve, reject) => {
-		let urlsTerms = "&searchTerms=";
-		let cnt = 0;
-		for(let i = 0;i<=parseInt(tSec/60);i++){
-			if(i != parseInt(tSec/60)) {
-				urlsTerms += getStamp(i*60) + "%20%7C%20";
-			} else {
-				urlsTerms += getStamp(i*60);
-			}
-			cnt++;
-		}
+		let urlsTerms = "";
 		resolve(urlsTerms);
 	});
 }


### PR DESCRIPTION
### Solution

Removing the `searchTerms` field would make the extension work in #14, also mentioned in #13.

In many cases all comments are being filtered out and that's why no timestamps show up in videos. 

### Explanation
I read over https://github.com/knightron0/tempus/issues/3 but using bars ` | ` and timestamps in `searchTerms` is not documented in the YouTube API. This was supposed to find comments matching multiple timestamp formats, is that right?

For example, if I want to get a comments list from [this video](https://www.youtube.com/watch?v=X6NJkWbM1xk), with texts that mention any timestamps in the form 1:xx or 2:xx or 3:xx minutes, I might expect this would work:

`searchTerms=0: | 1: | 2: | 3:`

That makes the URL:

`https://www.googleapis.com/youtube/v3/commentThreads?part=snippet&videoId=X6NJkWbM1xk&maxResults=100&fields=items%28snippet%2FtopLevelComment%2Fsnippet%2FtextOriginal%2C%20snippet%2FtopLevelComment%2Fsnippet%2FauthorDisplayName%2Csnippet%2FtopLevelComment%2Fid%29%2CnextPageToken&key=[API-KEY]&searchTerms=0%3A%20%7C%201%3A%20%7C%202%3A%20%7C%203%3A%20%7C%20`

But the result right now is:

```
{
  "items": [
    {
      "snippet": {
        "topLevelComment": {
          "id": "UgwF6ayYcPgZMMBTV8J4AaABAg",
          "snippet": {
            "textOriginal": "3 2 1 0 Backups for everything :D",
            "authorDisplayName": "@DarkAxi0m"
          }
        }
      }
    }
  ]
}
```
Only 1 item which contains all the text `0 1 2 3`, instead of timestamps at those times.