### PR TITLE
Replay comment box visible

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -319,7 +319,7 @@ function rerender(){
     if(!config.normalMarker) toggleClass("normalMarker");
 }
 
-function updateLiveCommentViewVisibility(updateConfig = true) {
+function updateLiveCommentViewVisibility() {
     const liveCommentView = document.getElementById("liveCommentView");
     const hasComments = Object.keys(commentsTime).length > 0;
 
@@ -327,14 +327,6 @@ function updateLiveCommentViewVisibility(updateConfig = true) {
         // Hide the live comment view
         if (liveCommentView) {
             liveCommentView.style.display = "none";
-        }
-
-        // Update config only if the flag is true
-        if (updateConfig) {
-            config.liveCommentView = false;
-            chrome.storage.local.set({ liveCommentView: config.liveCommentView }, function () {
-                console.log("Live comment view hidden and state saved.");
-            });
         }
     } else {
         // Show the live comment view if it's enabled in the config
@@ -380,7 +372,7 @@ function initialize(response){
     });
 
     // When initializing update live comment view visibility
-    updateLiveCommentViewVisibility(false);
+    updateLiveCommentViewVisibility();
 }
 
 chrome.storage.local.get(['heatmap', 'normalMarker', 'density', 'commentView', 'primaryColor', 'liveCommentView'], function(result) {
@@ -401,7 +393,7 @@ chrome.runtime.sendMessage({getComments: "True"}, function(response) {
     initialize(response);
 
      // Update live comment view visibility after comments are fetched
-    updateLiveCommentViewVisibility(false);
+    updateLiveCommentViewVisibility();
 });
 
 chrome.runtime.onMessage.addListener(
@@ -417,7 +409,7 @@ chrome.runtime.onMessage.addListener(
             initialize(request.comments);
 
             // Update live comment view visibility after tab update
-            updateLiveCommentViewVisibility(false);
+            updateLiveCommentViewVisibility();
 
             sendResponse({status: true});
         }


### PR DESCRIPTION
#12 Hide the replay comment box when a video has no comments. But don't affect its config for other videos, like when toggling the view and a video has comments.