### PR TITLE
Sort comments by likes

### DIFF
--- a/background.js
+++ b/background.js
@@ -53,8 +53,18 @@ function getDuration(vId, apiKey){
 	});
 }
 
+// Make url to get comment from YouTube API
 function makeUrl(videoId, apiKey, pageToken){
-	const fields = "&fields=items%28snippet%2FtopLevelComment%2Fsnippet%2FtextOriginal%2Csnippet%2FtopLevelComment%2Fsnippet%2FauthorDisplayName%2Csnippet%2FtopLevelComment%2Fid%2Creplies%2Fcomments%28snippet%2FtextOriginal%2Csnippet%2FauthorDisplayName%29%29%2CnextPageToken";
+	const fields = "&fields=items%28snippet%2FtopLevelComment%2Fsnippet%2FtextOriginal%2C" +  // comment text
+	"snippet%2FtopLevelComment%2Fsnippet%2FauthorDisplayName%2C" + // comment author
+	"snippet%2FtopLevelComment%2Fid%2C" + // comment id
+	"snippet%2FtopLevelComment%2Fsnippet%2FlikeCount%2C" + // like count
+	"replies%2Fcomments%28" + // replies
+	"snippet%2FtextOriginal%2C" + // reply text
+	"snippet%2FlikeCount%2C" + // reply like count
+	"snippet%2FauthorDisplayName" + // reply author
+	"%29%29%2C" + // end replies
+	"nextPageToken"; // end fields
 	let url = "https://www.googleapis.com/youtube/v3/commentThreads?part=snippet%2Creplies&videoId=";
 	url += videoId.toString() + "&maxResults=100" + fields + "&key=" + apiKey.toString();
 	if(pageToken != -1){
@@ -69,13 +79,14 @@ function filterComments(comments){
 		let textContent = comments[i]["snippet"]["topLevelComment"]["snippet"]["textOriginal"];
 		let user = comments[i]["snippet"]["topLevelComment"]["snippet"]["authorDisplayName"];
 		let commentId = comments[i]["snippet"]["topLevelComment"]["id"].trim();
+		const likeCount = comments[i]["snippet"]["topLevelComment"]["snippet"]["likeCount"];
 		const allStamps = textContent.match(/[0-9]{0,2}:{0,1}[0-9]{0,2}:[0-9][0-9]\s+/g);
 		let replies = getReplies(comments[i]);
 		if(allStamps != null){
 			const splitContent = textContent.split(new RegExp(/[0-9]{0,2}:{0,1}[0-9]{0,2}:[0-9][0-9]\s+/g));
 			for(var j = 0;j<allStamps.length;j++){
 				if(splitContent[j] == "" || splitContent[j][splitContent[j].length-1] == " "){
-					const timeStamp = {"time": allStamps[j].trim(), "text": textContent, "user": user, "id": commentId, "replies": replies};
+					const timeStamp = {"time": allStamps[j].trim(), "text": textContent, "user": user, "id": commentId, "replies": replies, "likeCount": likeCount};
 					res.push(timeStamp);
 				}
 			}
@@ -89,7 +100,7 @@ function getReplies(comment) {
 	if (comment["replies"] && comment["replies"]["comments"]) {
 		let replyComments = comment["replies"]["comments"];
 		for(var i = 0; i < replyComments.length; i++) { 
-			replies.push({"text": replyComments[i]["snippet"]["textOriginal"], "user": replyComments[i]["snippet"]["authorDisplayName"]})
+			replies.push({"text": replyComments[i]["snippet"]["textOriginal"], "user": replyComments[i]["snippet"]["authorDisplayName"], "likeCount": replyComments[i]?.snippet?.likeCount})
 		}
 	}
 	return replies;

--- a/content-script.js
+++ b/content-script.js
@@ -22,11 +22,13 @@ function editContent(content){
     return ans;
 }
 
-function makeCommentDiv(user, content, timestamp, id, isLive, parity, replies){
+function makeCommentDiv(user, content, timestamp, id, isLive, parity, replies, likeCount){
     const commentContainer = document.createElement('div');
     commentContainer.style.padding = "10px";
     commentContainer.style.fontSize = "13px";
     commentContainer.style.fontFamily = "Roboto";
+    // add data-like-count attribute
+    commentContainer.setAttribute('data-like-count', likeCount);
     if (parity == 1) {
         commentContainer.style.backgroundColor = "#1E1E1E";
     }
@@ -40,6 +42,14 @@ function makeCommentDiv(user, content, timestamp, id, isLive, parity, replies){
     username.style.fontWeight = "bold";
     username.style.lineHeight = "16px";
     username.innerHTML = user.toString();
+    const likeCountDiv = document.createElement('div');
+    likeCountDiv.style.float = "right";
+    likeCountDiv.style.color = "#999999";
+    likeCountDiv.style.display = "inline";
+    likeCountDiv.style.fontWeight = "bold";
+    likeCountDiv.style.lineHeight = "16px";
+    console.log(likeCount);
+    likeCountDiv.innerHTML = " likes: " + likeCount?.toString();
     const contentContainer = document.createElement('div');
     contentContainer.style.color = "white";
     contentContainer.style.overflowWrap = "break-word";
@@ -138,6 +148,7 @@ function makeCommentDiv(user, content, timestamp, id, isLive, parity, replies){
 
     commentContainer.appendChild(username);
     commentContainer.appendChild(contentContainer);
+    commentContainer.appendChild(likeCountDiv);
     if (replies.length > 0) {
         commentContainer.appendChild(toggleArrow);
         commentContainer.appendChild(replyCountText);
@@ -232,7 +243,8 @@ function onClickMarker(timestamp){
         for(let j = timestamp; j < timestamp+config.density; j++){
             if(j in commentsTime){
                 for(let i = 0; i < commentsTime[j].length; i++){
-                    let divCommentView = makeCommentDiv(commentsTime[j][i][1], commentsTime[j][i][0], -1, commentsTime[j][i][2], false, i&1, commentsTime[timestamp][i][3]);
+                    // Note: divCommentView take 5 arguments: user, content, timestamp, id, isLive, parity, replies, likeCount
+                    let divCommentView = makeCommentDiv(commentsTime[j][i][1], commentsTime[j][i][0], -1, commentsTime[j][i][2], false, i&1, commentsTime[timestamp][i][3], commentsTime[timestamp][i][4]);
                     document.getElementById("panelContent").appendChild(divCommentView);
                 }
             }
@@ -334,9 +346,13 @@ function initialize(response){
     for(let i = 0;i<response.length;i++){
         let num = getSeconds(response[i]["time"]);
         if(num in commentsTime){
-            commentsTime[num].push([response[i]["text"], response[i]["user"], response[i]["id"], response[i]["replies"]]);
+            // 5 elements in array: text, user, id, replies, likeCount
+            // This will be use to pass into makeCommentDiv
+            commentsTime[num].push([response[i]["text"], response[i]["user"], response[i]["id"], response[i]["replies"], response[i]["likeCount"]]);
         } else {
-            commentsTime[num] = [[response[i]["text"], response[i]["user"], response[i]["id"], response[i]["replies"]]];
+            // First time the comment time is encountered
+            // Create the nested array
+            commentsTime[num] = [[response[i]["text"], response[i]["user"], response[i]["id"], response[i]["replies"], response[i]["likeCount"]]];
         }
     }
     commentsResponse = response;
@@ -472,7 +488,8 @@ vid.ontimeupdate = function() {
                     if (placeholderImg != undefined) {
                         placeholderImg.style.display = 'none';
                     }
-                    divCommentView = makeCommentDiv(commentsTime[timestamp][i][1], commentsTime[timestamp][i][0], timestamp, commentsTime[timestamp][i][2], true, liveContent.getElementsByTagName('div').length & 1, commentsTime[timestamp][i][3]);
+                    // Note: divCommentView take 5 arguments: user, content, timestamp, id, isLive, parity, replies, likeCount
+                    divCommentView = makeCommentDiv(commentsTime[timestamp][i][1], commentsTime[timestamp][i][0], timestamp, commentsTime[timestamp][i][2], true, liveContent.getElementsByTagName('div').length & 1, commentsTime[timestamp][i][3], commentsTime[timestamp][i][4]);
                     liveContent.appendChild(divCommentView);
                     liveContent.scrollTop = liveContent.scrollHeight;
                 }

--- a/content-script.js
+++ b/content-script.js
@@ -48,8 +48,11 @@ function makeCommentDiv(user, content, timestamp, id, isLive, parity, replies, l
     likeCountDiv.style.display = "inline";
     likeCountDiv.style.fontWeight = "bold";
     likeCountDiv.style.lineHeight = "16px";
-    console.log(likeCount);
-    likeCountDiv.innerHTML = " likes: " + likeCount?.toString();
+    if (likeCount !== undefined) {
+        likeCountDiv.innerHTML = " likes: " + likeCount;
+    } else {
+        likeCountDiv.innerHTML = " likes: 0";
+    }
     const contentContainer = document.createElement('div');
     contentContainer.style.color = "white";
     contentContainer.style.overflowWrap = "break-word";

--- a/content-script.js
+++ b/content-script.js
@@ -181,7 +181,8 @@ function makePanel(ifLive){
         headerHtml = `
         <div id="panelHeader" style="position: relative; width:100%; height: 60px; background-color: #1D1D1D; border-radius: 2px 2px 0px 0px;">
             <div style="float:left; font-size: 16px; color:white; padding-top: 5%; padding-bottom:5%; padding-left:16px; font-family: 'Roboto';">Comments</div>
-            <div id="timestampView" style="position: relative; float:left; background-color: #24283A;font-size: 16px; color: #3EA6FF; top: 30%; margin-left: 2%; padding: 2px 5px 2px 5px; border-radius: 3px;">1:15:30</div>
+            <div id="timestampView" style="position: relative; float:left; background-color: #24283A;font-size: 16px; color: #3EA6FF; top: 30%; margin-left: 2%; padding: 2px 5px 2px 5px; border-radius: 3px;">Click marker</div>
+            <button id="sortToggleButton" style="position: relative; float:left; background-color: #24283A; color: #3EA6FF; border: none; border-radius: 3px; padding: 4px 8px; font-size: 12px; top: 30%; margin-left: 10px; cursor: pointer;">Sort By Likes</button>
             <button id="commentPanelButton" style="position: relative; border:none; float:right; top: 15%; background-color: transparent; outline: none; color: white; font-size: 35px; margin-right: 2%; cursor:pointer;">×</button>
         </div>`
     }
@@ -238,7 +239,7 @@ function onClickMarker(timestamp){
     vid.currentTime = timestamp;
     if(config.commentView){
         document.getElementById("commentView").style.display = "block";
-        document.getElementById("timestampView").innerHTML = (config.density === 1) ? getStamp(timestamp) : getStamp(timestamp) + " — " + getStamp(timestamp+config.density-1);
+        document.getElementById("timestampView").innerHTML = (config.density === 1) ? getStamp(timestamp) : getStamp(timestamp) + " — " + getStamp(timestamp+config.density-1);
         document.getElementById("panelContent").innerHTML = "";
         for(let j = timestamp; j < timestamp+config.density; j++){
             if(j in commentsTime){
@@ -369,6 +370,53 @@ function initialize(response){
         config.liveCommentView = false;
         chrome.storage.local.set({'liveCommentView': config.liveCommentView}, function() {});
     });
+
+    // Add sort mode state and event listener
+    let sortByLikes = false; // Default to original time-based order
+    let originalOrder = []; // Store original order of comments
+
+    let sortToggleButton = document.getElementById('sortToggleButton');
+    if (sortToggleButton) {
+        sortToggleButton.addEventListener('click', function() {
+            const panelContent = document.getElementById("panelContent");
+            if (panelContent) {
+                const comments = Array.from(panelContent.children);
+                
+                if (comments.length > 0) {
+                    if (!sortByLikes) {
+                        // Store original order if not already stored
+                        if (originalOrder.length === 0) {
+                            originalOrder = [...comments];
+                        }
+                        
+                        // Sort by likes
+                        const sortedComments = comments.sort((a, b) => {
+                            const likesA = parseInt(a.getAttribute('data-like-count') || 0);
+                            const likesB = parseInt(b.getAttribute('data-like-count') || 0);
+                            return likesB - likesA; // Sort in descending order
+                        });
+                        
+                        panelContent.innerHTML = "";
+                        sortedComments.forEach(comment => {
+                            panelContent.appendChild(comment);
+                        });
+                        
+                        sortToggleButton.innerHTML = "Sort By Time";
+                    } else {
+                        // Restore original order
+                        panelContent.innerHTML = "";
+                        originalOrder.forEach(comment => {
+                            panelContent.appendChild(comment);
+                        });
+                        
+                        sortToggleButton.innerHTML = "Sort By Likes";
+                    }
+                    
+                    sortByLikes = !sortByLikes;
+                }
+            }
+        });
+    }
 }
 
 chrome.storage.local.get(['heatmap', 'normalMarker', 'density', 'commentView', 'primaryColor', 'liveCommentView'], function(result) {


### PR DESCRIPTION
This PR adds a button the the comment panel to sort all comments with the same timestamp.

It...

- [x] adds likes to the request to YouTube API.
- [x] adds a small like label to each commentDiv that indicates its like count.
- [x] adds a button in the comment panel to sort by likeCount or by time. 

Note: It might be a good idea to add a new panel that displays all comments and can sort by likes. The comment panel usually does not have very many comments with the same timestamp, and it is easy to just look at the list to find what you need.